### PR TITLE
fix: improve handling of array/hash values

### DIFF
--- a/fluent-plugin-f5-beacon.gemspec
+++ b/fluent-plugin-f5-beacon.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name          = "fluent-plugin-f5-beacon"
-  s.version       = '0.0.1'
+  s.version       = '0.0.2'
   s.authors       = ["Matt Davey"]
   s.email         = ["m.davey@f5.com"]
   s.description   = %q{F5 Beacon output plugin for Fluentd}


### PR DESCRIPTION
Before:
Array/hash values resulted in malformed line protocol input that was silently rejected within Beacon, leaving a user questioning what happened.

After:
Array/hash values in tags are converted to strings.  All tag values are already treated as strings within Beacon.  Array/hash values in fields are discarded and logged.

`2020-08-10 22:20:29 +0000 [warn]: #0 [f5_beacon] array/hash field 'data' discarded; consider using a plugin to map`

We could consider treating tags similarly (i.e. discard & log), but given tag values must be strings, type conversion seems  expected/consistent.  String conversion only applies when using the tag_keys parameter to manually specify the tags.