### PR TITLE
fix: update precision for custom time keys

### DIFF
--- a/fluent-plugin-f5-beacon.gemspec
+++ b/fluent-plugin-f5-beacon.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name          = "fluent-plugin-f5-beacon"
-  s.version       = '0.0.2'
+  s.version       = '0.0.3'
   s.authors       = ["Matt Davey"]
   s.email         = ["m.davey@f5.com"]
   s.description   = %q{F5 Beacon output plugin for Fluentd}

--- a/lib/fluent/plugin/out_f5_beacon.rb
+++ b/lib/fluent/plugin/out_f5_beacon.rb
@@ -36,7 +36,7 @@ module Fluent::Plugin class BeaconOutput < Output
   config_param :measurement, :string, default: nil,
                desc: "The measurement name to insert event.  If not specified, fluentd's tag is used."
   config_param :time_key, :string, default: 'time',
-               desc: 'Use value of this tag if it exists in event instead of event timestamp.'
+               desc: 'Use value of this tag if it exists in event instead of event timestamp.  Values must be in Epoch time.'
   config_param :auto_tags, :bool, default: false,
                desc: "Enable/disable auto-tagging behavior which makes strings tags."
   config_param :tag_keys, :array, default: [],

--- a/lib/fluent/plugin/out_f5_beacon.rb
+++ b/lib/fluent/plugin/out_f5_beacon.rb
@@ -101,7 +101,7 @@ events and reset to zero for a new event with the different timestamp.
     points = []
     tag = chunk.metadata.tag
     chunk.msgpack_each do |time, record|
-      timestamp = record.delete(@time_key) || time
+      timestamp = precision_time(record.delete(@time_key)) || time
       if tag_keys.empty? && !@auto_tags
         values = record
         tags = {}
@@ -120,7 +120,6 @@ events and reset to zero for a new event with the different timestamp.
           end
         end
       end
-
       if @sequence_tag
         if @prev_timestamp == timestamp
           @seq += 1
@@ -179,6 +178,8 @@ events and reset to zero for a new event with the different timestamp.
   end
 
   def precision_time(time)
+    return if time.nil?
+
     # nsec is supported from v0.14
     time * (10 ** 9) + (time.is_a?(Integer) ? 0 : time.nsec)
   end
@@ -236,3 +237,4 @@ events and reset to zero for a new event with the different timestamp.
 
 end
 end
+

--- a/test/plugin/test_out_f5_beacon.rb
+++ b/test/plugin/test_out_f5_beacon.rb
@@ -389,7 +389,7 @@ class BeaconOutputTest < Test::Unit::TestCase
 
     time = event_time("2020-01-02 13:14:15 UTC")
     driver.run(default_tag: 'input.influxdb') do
-      driver.feed(time, {'a' => 1, 'b' => 1293974055000000000})
+      driver.feed(time, {'a' => 1, 'b' => 1293974055})
     end
 
     assert_equal([


### PR DESCRIPTION
Beacon timestamps have ns precision.  The plugin expected custom time keys to align accordingly.  After spending ample time looking at options for translating timestamps, I found translating to Epoch time to be more standard/simple in Fluentd.  This change makes Epoch time the default for custom keys.  As a later enhancement, we can add an additional parameter to define the precision for flexibility.  A corresponding docs update will follow with more detail.